### PR TITLE
Add standard repo files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,68 @@
+# Contributing to `ftrucli`
+
+We love your input! We want to make contributing to this project as easy and transparent as possible, whether it's:
+
+- Reporting a bug
+- Discussing the current state of the code
+- Submitting a fix
+- Proposing new features
+- Becoming a maintainer
+
+This document introduces contribution practices for `ftrucli`.
+
+- [Contributing to `ftrucli`](#contributing-to-ftrucli)
+  - [We Develop with GitHub](#we-develop-with-github)
+  - [We Use Release Flow](#we-use-release-flow)
+  - [Report bugs using GitHub's issues](#report-bugs-using-githubs-issues)
+  - [Use a Consistent Coding Style](#use-a-consistent-coding-style)
+  - [License](#license)
+  - [`CONTRIBUTING.md` template](#contributingmd-template)
+
+## We Develop with GitHub
+
+We use github to host code, track issues and feature requests, and accept pull requests.
+
+## We Use [Release Flow](https://docs.microsoft.com/en-us/azure/devops/learn/devops-at-microsoft/release-flow)
+
+Pull requests are the best way to propose changes to the codebase (we use [Release Flow](https://docs.microsoft.com/en-us/azure/devops/learn/devops-at-microsoft/release-flow)). We actively welcome your pull requests:
+
+1. Fork the repo and create your branch from `main`.
+2. If you've added code that should be tested, add tests.
+3. If you've changed APIs, update the documentation.
+4. Ensure the test suite passes.
+5. Make sure your code lints.
+6. Issue that pull request!
+
+## Report bugs using GitHub's [issues](https://github.com/SpaceKatt/ftrucli/issues)
+
+We use GitHub issues to track public bugs. Report a bug by [opening a new issue](https://github.com/SpaceKatt/ftrucli/issues/new/choose); it's that easy!
+
+Write bug reports with detail, background, and sample code
+
+**Great Bug Reports** tend to have:
+
+- A quick summary and/or background
+- Steps to reproduce
+  - Be specific!
+  - Give sample code if you can.
+- What you expected would happen
+- What actually happens
+- Notes (possibly including why you think this might be happening, or stuff you tried that didn't work)
+
+People _love_ thorough bug reports. I'm not even kidding.
+
+## Use a Consistent Coding Style
+
+See [Linting](./README.md#Linting) to learn about this project's enforced coding style.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under its MIT License.
+
+In short, when you submit code changes, your submissions are understood to be under the same [MIT License](http://choosealicense.com/licenses/mit/) that covers the project.
+
+Public data from San Francisco's SODA endpoint is covered under the [Public Domain Dedication and License](https://opendatacommons.org/licenses/pddl/1-0/), see the [LICENSE-DATA](LICENSE-DATA) file.
+
+## `CONTRIBUTING.md` template
+
+[This template](https://github.com/SpaceKatt/spacekatt-io/blob/main/CONTRIBUTING.md) (and—by the transitive property—[this template](https://gist.github.com/briandk/3d2e8b3ec8daf5a27a62) too) was used in the creation of this document.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Thomas Kercheval
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE-DATA
+++ b/LICENSE-DATA
@@ -1,0 +1,208 @@
+Public Domain Dedication and License (PDDL)
+
+
+Preamble
+
+
+The Open Data Commons – Public Domain Dedication and Licence is a document intended to allow you to freely share, modify, and use this work for any purpose and without any restrictions. This licence is intended for use on databases or their contents (“data”), either together or individually.
+
+
+Many databases are covered by copyright. Some jurisdictions, mainly in Europe, have specific special rights that cover databases called the “sui generis” database right. Both of these sets of rights, as well as other legal rights used to protect databases and data, can create uncertainty or practical difficulty for those wishing to share databases and their underlying data but retain a limited amount of rights under a “some rights reserved” approach to licensing as outlined in the Science Commons Protocol for Implementing Open Access Data. As a result, this waiver and licence tries to the fullest extent possible to eliminate or fully license any rights that cover this database and data. Any Community Norms or similar statements of use of the database or data do not form a part of this document, and do not act as a contract for access or other terms of use for the database or data.
+
+
+The position of the recipient of the work
+
+
+Because this document places the database and its contents in or as close as possible within the public domain, there are no restrictions or requirements placed on the recipient by this document. Recipients may use this work commercially, use technical protection measures, combine this data or database with other databases or data, and share their changes and additions or keep them secret. It is not a requirement that recipients provide further users with a copy of this licence or attribute the original creator of the data or database as a source. The goal is to eliminate restrictions held by the original creator of the data and database on the use of it by others.
+
+
+The position of the dedicator of the work
+
+
+Copyright law, as with most other law under the banner of “intellectual property”, is inherently national law. This means that there exists several differences in how copyright and other IP rights can be relinquished, waived or licensed in the many legal jurisdictions of the world. This is despite much harmonisation of minimum levels of protection. The internet and other communication technologies span these many disparate legal jurisdictions and thus pose special difficulties for a document relinquishing and waiving intellectual property rights, including copyright and database rights, for use by the global community. Because of this feature of intellectual property law, this document first relinquishes the rights and waives the relevant rights and claims. It then goes on to license these same rights for jurisdictions or areas of law that may make it difficult to relinquish or waive rights or claims.
+
+
+The purpose of this document is to enable rightsholders to place their work into the public domain. Unlike licences for free and open source software, free cultural works, or open content licences, rightsholders will not be able to “dual license” their work by releasing the same work under different licences. This is because they have allowed anyone to use the work in whatever way they choose. Rightsholders therefore can’t re-license it under copyright or database rights on different terms because they have nothing left to license. Doing so creates truly accessible data to build rich applications and advance the progress of science and the arts.
+
+
+This document can cover either or both of the database and its contents (the data). Because databases can have a wide variety of content – not just factual data – rightsholders should use the Open Data Commons – Public Domain Dedication & Licence for an entire database and its contents only if everything can be placed under the terms of this document. Because even factual data can sometimes have intellectual property rights, rightsholders should use this licence to cover both the database and its factual data when making material available under this document; even if it is likely that the data would not be covered by copyright or database rights.
+
+
+Rightsholders can also use this document to cover any copyright or database rights claims over only a database, and leave the contents to be covered by other licences or documents. They can do this because this document refers to the “Work”, which can be either – or both – the database and its contents. As a result, rightsholders need to clearly state what they are dedicating under this document when they dedicate it.
+
+
+Just like any licence or other document dealing with intellectual property, rightsholders should be aware that one can only license what one owns. Please ensure that the rights have been cleared to make this material available under this document.
+
+
+This document permanently and irrevocably makes the Work available to the public for any use of any kind, and it should not be used unless the rightsholder is prepared for this to happen.
+
+
+Part I: Introduction
+
+
+The Rightsholder (the Person holding rights or claims over the Work) agrees as follows:
+
+
+1.0 Definitions of Capitalised Words
+
+
+“Copyright” – Includes rights under copyright and under neighbouring rights and similarly related sets of rights under the law of the relevant jurisdiction under Section 6.4.
+
+
+“Data” – The contents of the Database, which includes the information, independent works, or other material collected into the Database offered under the terms of this Document.
+
+
+“Database” – A collection of Data arranged in a systematic or methodical way and individually accessible by electronic or other means offered under the terms of this Document.
+
+
+“Database Right” – Means rights over Data resulting from the Chapter III (“sui generis”) rights in the Database Directive (Directive 96/9/EC of the European Parliament and of the Council of 11 March 1996 on the legal protection of databases) and any future updates as well as any similar rights available in the relevant jurisdiction under Section 6.4.
+
+
+“Document” – means this relinquishment and waiver of rights and claims and back up licence agreement.
+
+
+“Person” – Means a natural or legal person or a body of persons corporate or incorporate.
+
+
+“Use” – As a verb, means doing any act that is restricted by Copyright or Database Rights whether in the original medium or any other; and includes modifying the Work as may be technically necessary to use it in a different mode or format. This includes the right to sublicense the Work.
+
+
+“Work” – Means either or both of the Database and Data offered under the terms of this Document.
+
+
+“You” – the Person acquiring rights under the licence elements of this Document.
+
+
+Words in the singular include the plural and vice versa.
+
+
+2.0 What this document covers
+
+
+2.1. Legal effect of this Document. This Document is:
+
+
+    a. A dedication to the public domain and waiver of Copyright and Database Rights over the Work; and
+
+
+    b. A licence of Copyright and Database Rights over the Work in jurisdictions that do not allow for relinquishment or waiver.
+
+
+2.2. Legal rights covered.
+
+
+    a. Copyright. Any copyright or neighbouring rights in the Work. Copyright law varies between jurisdictions, but is likely to cover: the Database model or schema, which is the structure, arrangement, and organisation of the Database, and can also include the Database tables and table indexes; the data entry and output sheets; and the Field names of Data stored in the Database. Copyright may also cover the Data depending on the jurisdiction and type of Data; and
+
+
+    b. Database Rights. Database Rights only extend to the extraction and re-utilisation of the whole or a substantial part of the Data. Database Rights can apply even when there is no copyright over the Database. Database Rights can also apply when the Data is removed from the Database and is selected and arranged in a way that would not infringe any applicable copyright.
+
+
+2.2 Rights not covered.
+
+
+    a. This Document does not apply to computer programs used in the making or operation of the Database;
+
+
+    b. This Document does not cover any patents over the Data or the Database. Please see Section 4.2 later in this Document for further details; and
+
+
+    c. This Document does not cover any trade marks associated with the Database. Please see Section 4.3 later in this Document for further details.
+
+
+Users of this Database are cautioned that they may have to clear other rights or consult other licences.
+
+
+2.3 Facts are free. The Rightsholder takes the position that factual information is not covered by Copyright. This Document however covers the Work in jurisdictions that may protect the factual information in the Work by Copyright, and to cover any information protected by Copyright that is contained in the Work.
+
+
+Part II: Dedication to the public domain
+
+
+3.0 Dedication, waiver, and licence of Copyright and Database Rights
+
+
+3.1 Dedication of Copyright and Database Rights to the public domain. The Rightsholder by using this Document, dedicates the Work to the public domain for the benefit of the public and relinquishes all rights in Copyright and Database Rights over the Work.
+
+
+a. The Rightsholder realises that once these rights are relinquished, that the Rightsholder has no further rights in Copyright and Database Rights over the Work, and that the Work is free and open for others to Use.
+
+
+b. The Rightsholder intends for their relinquishment to cover all present and future rights in the Work under Copyright and Database Rights, whether they are vested or contingent rights, and that this relinquishment of rights covers all their heirs and successors.
+
+
+The above relinquishment of rights applies worldwide and includes media and formats now known or created in the future.
+
+
+3.2 Waiver of rights and claims in Copyright and Database Rights when Section 3.1 dedication inapplicable. If the dedication in Section 3.1 does not apply in the relevant jurisdiction under Section 6.4, the Rightsholder waives any rights and claims that the Rightsholder may have or acquire in the future over the Work in:
+
+
+a. Copyright; and
+
+
+b. Database Rights.
+
+
+To the extent possible in the relevant jurisdiction, the above waiver of rights and claims applies worldwide and includes media and formats now known or created in the future. The Rightsholder agrees not to assert the above rights and waives the right to enforce them over the Work.
+
+
+3.3 Licence of Copyright and Database Rights when Sections 3.1 and 3.2 inapplicable. If the dedication and waiver in Sections 3.1 and 3.2 does not apply in the relevant jurisdiction under Section 6.4, the Rightsholder and You agree as follows:
+
+
+a. The Licensor grants to You a worldwide, royalty-free, non-exclusive, licence to Use the Work for the duration of any applicable Copyright and Database Rights. These rights explicitly include commercial use, and do not exclude any field of endeavour. To the extent possible in the relevant jurisdiction, these rights may be exercised in all media and formats whether now known or created in the future.
+
+
+3.4 Moral rights. This section covers moral rights, including the right to be identified as the author of the Work or to object to treatment that would otherwise prejudice the author’s honour and reputation, or any other derogatory treatment:
+
+
+a. For jurisdictions allowing waiver of moral rights, Licensor waives all moral rights that Licensor may have in the Work to the fullest extent possible by the law of the relevant jurisdiction under Section 6.4;
+
+
+b. If waiver of moral rights under Section 3.4 a in the relevant jurisdiction is not possible, Licensor agrees not to assert any moral rights over the Work and waives all claims in moral rights to the fullest extent possible by the law of the relevant jurisdiction under Section 6.4; and
+
+
+c. For jurisdictions not allowing waiver or an agreement not to assert moral rights under Section 3.4 a and b, the author may retain their moral rights over the copyrighted aspects of the Work.
+
+
+Please note that some jurisdictions do not allow for the waiver of moral rights, and so moral rights may still subsist over the work in some jurisdictions.
+
+
+4.0 Relationship to other rights
+
+
+4.1 No other contractual conditions. The Rightsholder makes this Work available to You without any other contractual obligations, either express or implied. Any Community Norms statement associated with the Work is not a contract and does not form part of this Document.
+
+
+4.2 Relationship to patents. This Document does not grant You a licence for any patents that the Rightsholder may own. Users of this Database are cautioned that they may have to clear other rights or consult other licences.
+
+
+4.3 Relationship to trade marks. This Document does not grant You a licence for any trade marks that the Rightsholder may own or that the Rightsholder may use to cover the Work. Users of this Database are cautioned that they may have to clear other rights or consult other licences.
+
+
+Part III: General provisions
+
+
+5.0 Warranties, disclaimer, and limitation of liability
+
+
+5.1 The Work is provided by the Rightsholder “as is” and without any warranty of any kind, either express or implied, whether of title, of accuracy or completeness, of the presence of absence of errors, of fitness for purpose, or otherwise. Some jurisdictions do not allow the exclusion of implied warranties, so this exclusion may not apply to You.
+
+
+5.2 Subject to any liability that may not be excluded or limited by law, the Rightsholder is not liable for, and expressly excludes, all liability for loss or damage however and whenever caused to anyone by any use under this Document, whether by You or by anyone else, and whether caused by any fault on the part of the Rightsholder or not. This exclusion of liability includes, but is not limited to, any special, incidental, consequential, punitive, or exemplary damages. This exclusion applies even if the Rightsholder has been advised of the possibility of such damages.
+
+
+5.3 If liability may not be excluded by law, it is limited to actual and direct financial loss to the extent it is caused by proved negligence on the part of the Rightsholder.
+
+
+6.0 General
+
+
+6.1 If any provision of this Document is held to be invalid or unenforceable, that must not affect the validity or enforceability of the remainder of the terms of this Document.
+
+
+6.2 This Document is the entire agreement between the parties with respect to the Work covered here. It replaces any earlier understandings, agreements or representations with respect to the Work not specified here.
+
+
+6.3 This Document does not affect any rights that You or anyone else may independently have under any applicable law to make any use of this Work, including (for jurisdictions where this Document is a licence) fair dealing, fair use, database exceptions, or any other legally recognised limitation or exception to infringement of copyright or other applicable laws.
+
+
+6.4 This Document takes effect in the relevant jurisdiction in which the Document terms are sought to be enforced. If the rights waived or granted under applicable law in the relevant jurisdiction includes additional rights not waived or granted under this Document, these additional rights are included in this Document in order to meet the intent of this Document.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,23 @@
 # ftrucli
 
+`ftrucli` is a Food Truck CLI used to find food trucks near a geospatial coordinate (especially in San Francisco).
+
 - [ftrucli](#ftrucli)
+  - [MVP Design Meta](#mvp-design-meta)
+  - [CLI Instructions](#cli-instructions)
+    - [Installation](#installation)
+    - [Usage](#usage)
+  - [Development](#development)
+    - [Build](#build)
+    - [Test](#test)
+    - [Linting](#linting)
+  - [CI/CD](#cicd)
+    - [Continuous Integration](#continuous-integration)
+    - [Continuous Deployment](#continuous-deployment)
+  - [Publishing](#publishing)
+    - [`npm` Publishing](#npm-publishing)
+    - [Versioning](#versioning)
+  - [Decision Log](#decision-log)
 
 ## MVP Design Meta
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,36 @@
 # ftrucli
+
+- [ftrucli](#ftrucli)
+
+## MVP Design Meta
+
+## CLI Instructions
+
+### Installation
+
+### Usage
+
+## Development
+
+### Build
+
+### Test
+
+### Linting
+
+## CI/CD
+
+### Continuous Integration
+
+### Continuous Deployment
+
+## Publishing
+
+### `npm` Publishing
+
+### Versioning
+
+## Decision Log
+
+| Decision | Description |
+| -------- | ----------- |


### PR DESCRIPTION
# Work Item

[Project Card](https://github.com/SpaceKatt/ftrucli/projects/1#card-58804674)

# Description

This PR brings this PR into alignment with the [CSE playbook](https://github.com/microsoft/code-with-engineering-playbook)'s guidance on [standard repository files](https://microsoft.github.io/code-with-engineering-playbook/source-control/#creating-a-new-repository).

Standard files added:

- `CONTRIBUTING.md`
- `LICENSE`
- `LICENSE-DATA` - to cover data from San Francisco's SODA endpoint

`README.md` was updated with a generic structure.