### PR TITLE
Add CityClient interface and implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
   - [CLI Instructions](#cli-instructions)
     - [Installation](#installation)
     - [Usage](#usage)
+      - [Help Dump](#help-dump)
+      - [Usage Examples](#usage-examples)
   - [Development](#development)
     - [Dependencies](#dependencies)
       - [Install `node14`, using `nvm`](#install-node14-using-nvm)
@@ -75,7 +77,61 @@ Author _may_ or may not have time to implement factories for extensibility. If t
 
 ### Installation
 
+Install the CLI globally from npm.
+
+```bash
+npm install --global trucli
+```
+
 ### Usage
+
+This section contains the CLI help messages and some examples
+
+#### Help Dump
+
+General help dump...
+
+```bash
+usage: ftrucli [-h] [-v] <command> ...
+
+Food Truck CLI used to find food trucks near a geospatial coordinate
+(especially in San Francisco).
+
+Positional arguments:
+  <command>
+    coord        Finds food trucks within a specified distance from a
+                 coordinate pair.
+
+Optional arguments:
+  -h, --help     Show this help message and exit.
+  -v, --verbose  Print out all the debug!
+
+For detailed help about a specific command, use: trucli <command> -h
+```
+
+`coord` command help dump...
+
+```bash
+$ ftrucli
+usage: ftrucli coord [-h] --long LONGITUDE --lat LATITUDE [-n LIMIT]
+                    [-d DISTANCE]
+
+
+TODO: more docs here.
+
+Optional arguments:
+  -h, --help            Show this help message and exit.
+  --long LONGITUDE      A user's longitude.
+  --lat LATITUDE        A user's latitude.
+  -n LIMIT, --limit LIMIT
+                        Limits the number of responses returned from a SODA
+                        query. The default value is 6.
+  -d DISTANCE, --distance DISTANCE
+                        The distance (in meters) to search outwards from a
+                        coordinate point. The default value is 5000.
+```
+
+#### Usage Examples
 
 ```bash
 trucli coord --lat 37.80 --long -122.43

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   },
   "homepage": "https://github.com/SpaceKatt/ftrucli#readme",
   "dependencies": {
-    "@rushstack/ts-command-line": "^4.7.9"
+    "@rushstack/ts-command-line": "^4.7.9",
+    "axios": "0.21.1"
   },
   "devDependencies": {
     "@rushstack/eslint-config": "^2.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,6 @@
 dependencies:
   '@rushstack/ts-command-line': 4.7.9
+  axios: 0.21.1
 devDependencies:
   '@rushstack/eslint-config': 2.3.3_eslint@7.24.0+typescript@4.2.4
   '@rushstack/heft': 0.28.1
@@ -1305,6 +1306,12 @@ packages:
     dev: true
     resolution:
       integrity: sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
+  /axios/0.21.1:
+    dependencies:
+      follow-redirects: 1.13.3
+    dev: false
+    resolution:
+      integrity: sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
   /babel-jest/25.5.1_@babel+core@7.13.15:
     dependencies:
       '@babel/core': 7.13.15
@@ -2502,6 +2509,17 @@ packages:
     dev: true
     resolution:
       integrity: sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==
+  /follow-redirects/1.13.3:
+    dev: false
+    engines:
+      node: '>=4.0'
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+    resolution:
+      integrity: sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA==
   /for-in/1.0.2:
     dev: true
     engines:
@@ -6163,5 +6181,6 @@ specifiers:
   '@types/heft-jest': ^1.0.2
   '@types/jest': ^26.0.22
   '@types/node': ^14.14.37
+  axios: 0.21.1
   eslint: ^7.24.0
   typescript: ^4.2.4

--- a/src/actions/coordAction.ts
+++ b/src/actions/coordAction.ts
@@ -6,6 +6,7 @@ import {
   CommandLineStringParameter,
 } from '@rushstack/ts-command-line';
 import { SodaQueryBuilder } from '../builders';
+import { SfSodaClient } from '../services/sfSodaClient';
 
 export class CoordAction extends CommandLineAction {
   private _distance!: CommandLineIntegerParameter;
@@ -32,9 +33,15 @@ export class CoordAction extends CommandLineAction {
       .withDistance(this._distance.value!)
       .buildQuery();
 
+    const cityClient = new SfSodaClient();
+    const data = await cityClient.runQuery(query);
+
+    // TODO: gather --output flag and use it to construct
+    //       output object from factory, to enable other
+    //       types of output
     const output = new JsonOutput();
 
-    output.print(query);
+    output.print(data);
   }
 
   protected onDefineParameters(): void {

--- a/src/constants/ftrucliConstants.ts
+++ b/src/constants/ftrucliConstants.ts
@@ -1,6 +1,6 @@
 // intent, split constants into semantic groups
 // everything in one class, for now, due to time constraints
 export class FtrucliConstans {
-  static readonly outputJson: string = "json";
-  static readonly outputTable: string = "table";
+  static readonly apiEndpoint: string =
+    'https://data.sfgov.org/resource/rqzj-sfat.json';
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,18 +2,18 @@
 import {
   CommandLineFlagParameter,
   CommandLineParser,
-} from "@rushstack/ts-command-line";
+} from '@rushstack/ts-command-line';
 
-import { CoordAction } from "./actions";
+import { CoordAction } from './actions';
 
 export class TrucliCommandLine extends CommandLineParser {
   private _verbose!: CommandLineFlagParameter;
 
   constructor() {
     super({
-      toolFilename: "trucli",
+      toolFilename: 'ftrucli',
       toolDescription:
-        "Food Truck CLI used to find food trucks near a geospatial coordinate (especially in San Francisco).",
+        'Food Truck CLI used to find food trucks near a geospatial coordinate (especially in San Francisco).',
     });
 
     this.addAction(new CoordAction());
@@ -21,9 +21,9 @@ export class TrucliCommandLine extends CommandLineParser {
 
   protected onDefineParameters(): void {
     this._verbose = this.defineFlagParameter({
-      parameterLongName: "--verbose",
-      parameterShortName: "-v",
-      description: "Print out all the debug!",
+      parameterLongName: '--verbose',
+      parameterShortName: '-v',
+      description: 'Print out all the debug!',
     });
   }
 

--- a/src/interfaces/cityClient.ts
+++ b/src/interfaces/cityClient.ts
@@ -1,0 +1,4 @@
+export interface CityClient {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  runQuery(query: string): Promise<any>;
+}

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -1,2 +1,3 @@
+export * from './cityClient';
 export * from './output';
 export * from './queryBuilder';

--- a/src/services/sfSodaClient.ts
+++ b/src/services/sfSodaClient.ts
@@ -1,0 +1,28 @@
+import { CityClient } from '../interfaces';
+
+import axios from 'axios';
+import { FtrucliConstans } from '../constants/ftrucliConstants';
+
+function encode(val: string): string {
+  return encodeURIComponent(val)
+    .replace(/%3A/gi, ':')
+    .replace(/%24/g, '$')
+    .replace(/%2C/gi, ',')
+    .replace(/%20/g, '+')
+    .replace(/%5B/gi, '[')
+    .replace(/%5D/gi, ']');
+}
+
+export class SfSodaClient implements CityClient {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async runQuery(query: string): Promise<any> {
+    const encodedQuery = encode(query);
+    const request = `${FtrucliConstans.apiEndpoint}?$query=${encodedQuery}`;
+
+    let data;
+    await axios.get(request).then((response) => {
+      data = response.data;
+    });
+    return data;
+  }
+}


### PR DESCRIPTION
# Work Item

[Project Card](https://github.com/SpaceKatt/ftrucli/projects/1#card-58807003)

# Description

This PR defines the `CityClient` interface and implements the `SfSodaClient` class, to fetch data from SF's Socrates API.

Change summary...

- add `axios` dependency
- add `CityClient` interface
- implement `SfSodaClient`
- integrate `SfSodaClient` into CLI
- update `README`