### PR TITLE
Implement OutputFactory

### DIFF
--- a/src/actions/coordAction.ts
+++ b/src/actions/coordAction.ts
@@ -1,12 +1,12 @@
+import { SodaQueryBuilder } from '../builders';
 import { JsonOutput } from '../output';
+import { SfSodaClient } from '../services';
 
 import {
   CommandLineAction,
   CommandLineIntegerParameter,
   CommandLineStringParameter,
 } from '@rushstack/ts-command-line';
-import { SodaQueryBuilder } from '../builders';
-import { SfSodaClient } from '../services/sfSodaClient';
 
 export class CoordAction extends CommandLineAction {
   private _distance!: CommandLineIntegerParameter;

--- a/src/actions/coordAction.ts
+++ b/src/actions/coordAction.ts
@@ -1,5 +1,4 @@
 import { SodaQueryBuilder } from '../builders';
-import { JsonOutput } from '../output';
 import { SfSodaClient } from '../services';
 
 import {
@@ -9,6 +8,7 @@ import {
   CommandLineStringParameter,
 } from '@rushstack/ts-command-line';
 import { allOutputTypes, OutputType } from '../interfaces';
+import { OutputFactory } from '../factories';
 
 export class CoordAction extends CommandLineAction {
   private _distance!: CommandLineIntegerParameter;
@@ -40,10 +40,8 @@ export class CoordAction extends CommandLineAction {
     const cityClient = new SfSodaClient();
     const data = await cityClient.runQuery(query);
 
-    // TODO: gather --output flag and use it to construct
-    //       output object from factory, to enable other
-    //       types of output
-    const output = new JsonOutput();
+    const outputType = this._output.value!;
+    const output = OutputFactory.createOutput(outputType as OutputType);
 
     output.print(data);
   }

--- a/src/actions/coordAction.ts
+++ b/src/actions/coordAction.ts
@@ -1,4 +1,6 @@
 import { SodaQueryBuilder } from '../builders';
+import { allOutputTypes, OutputType } from '../interfaces';
+import { OutputFactory } from '../factories';
 import { SfSodaClient } from '../services';
 
 import {
@@ -7,8 +9,6 @@ import {
   CommandLineIntegerParameter,
   CommandLineStringParameter,
 } from '@rushstack/ts-command-line';
-import { allOutputTypes, OutputType } from '../interfaces';
-import { OutputFactory } from '../factories';
 
 export class CoordAction extends CommandLineAction {
   private _distance!: CommandLineIntegerParameter;

--- a/src/actions/coordAction.ts
+++ b/src/actions/coordAction.ts
@@ -4,15 +4,18 @@ import { SfSodaClient } from '../services';
 
 import {
   CommandLineAction,
+  CommandLineChoiceParameter,
   CommandLineIntegerParameter,
   CommandLineStringParameter,
 } from '@rushstack/ts-command-line';
+import { allOutputTypes, OutputType } from '../interfaces';
 
 export class CoordAction extends CommandLineAction {
   private _distance!: CommandLineIntegerParameter;
   private _limit!: CommandLineIntegerParameter;
   private _lat!: CommandLineStringParameter;
   private _long!: CommandLineStringParameter;
+  private _output!: CommandLineChoiceParameter;
 
   constructor() {
     super({
@@ -72,6 +75,13 @@ export class CoordAction extends CommandLineAction {
       description:
         'The distance (in meters) to search outwards from a coordinate point.',
       defaultValue: 5000,
+    });
+    this._output = this.defineChoiceParameter({
+      parameterLongName: '--output',
+      parameterShortName: '-o',
+      description: 'Determines how the results are displayed.',
+      alternatives: allOutputTypes,
+      defaultValue: OutputType.prettyJson,
     });
   }
 }

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,1 @@
+export * from './ftrucliConstants';

--- a/src/factories/index.ts
+++ b/src/factories/index.ts
@@ -1,0 +1,1 @@
+export * from './outputFactory';

--- a/src/factories/outputFactory.ts
+++ b/src/factories/outputFactory.ts
@@ -1,0 +1,13 @@
+import { OutputType, Output } from '../interfaces';
+import { JsonOutput } from '../output';
+
+export class OutputFactory {
+  static createOutput(kind: OutputType): Output {
+    switch (kind) {
+      case OutputType.prettyJson:
+        return new JsonOutput();
+      default:
+        throw new TypeError(`Unknown type ${kind} given to OutputFactory`);
+    }
+  }
+}

--- a/src/factories/outputFactory.ts
+++ b/src/factories/outputFactory.ts
@@ -7,7 +7,7 @@ export class OutputFactory {
       case OutputType.prettyJson:
         return new JsonOutput();
       default:
-        throw new TypeError(`Unknown type ${kind} given to OutputFactory`);
+        throw new TypeError(`Unknown type "${kind}" given to OutputFactory`);
     }
   }
 }

--- a/src/interfaces/output.ts
+++ b/src/interfaces/output.ts
@@ -2,6 +2,8 @@ export enum OutputType {
   prettyJson = 'prettyJson',
 }
 
+export const allOutputTypes: string[] = Object.keys(OutputType);
+
 export interface Output {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   print(data: any): void;

--- a/src/interfaces/output.ts
+++ b/src/interfaces/output.ts
@@ -1,3 +1,7 @@
+export enum OutputType {
+  prettyJson = 'prettyJson',
+}
+
 export interface Output {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   print(data: any): void;

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,0 +1,1 @@
+export * from './sfSodaClient';

--- a/src/services/sfSodaClient.ts
+++ b/src/services/sfSodaClient.ts
@@ -1,7 +1,7 @@
+import { FtrucliConstans } from '../constants';
 import { CityClient } from '../interfaces';
 
 import axios from 'axios';
-import { FtrucliConstans } from '../constants/ftrucliConstants';
 
 function encode(val: string): string {
   return encodeURIComponent(val)


### PR DESCRIPTION
# Work Item

[Project card](https://github.com/SpaceKatt/ftrucli/projects/2#card-59269946)

# Description

This PR adds a factory for building `Output` objects and integrates it into ftrucli.

Change summary...

- fix `index.ts` import strategy
- add `OutputTypes` enum
- add `OutputFactory`
- integrate `OurputFactory` into `CoordAction`